### PR TITLE
Fix not saved faculty choice during registration

### DIFF
--- a/app/Forms/SignUpFormFactory.php
+++ b/app/Forms/SignUpFormFactory.php
@@ -161,7 +161,7 @@ class SignUpFormFactory
             ->addRule(Form::PATTERN, 'Please Enter a valid phone number. International numbers start with \'+\' and country code (ex. +33155555555)', $this->internationalDialRegex)
             ->setRequired("What's your phone number?");*/
 
-        $form->addSelect('faculty', $this->translator->translate("sign.setup.faculty"), $faculties["long"])
+        $form->addSelect('faculty_id', $this->translator->translate("sign.setup.faculty"), $faculties["long"])
             ->setPrompt($this->translator->translate("sign.setup.faculty"))
             ->setRequired($this->translator->translate("sign.setup.requiredFaculty"));
 

--- a/app/Modules/Admin/templates/Sign/continue.latte
+++ b/app/Modules/Admin/templates/Sign/continue.latte
@@ -56,7 +56,7 @@
                 </div>
 
                 <div class="form-group">
-                    {input faculty}
+                    {input faculty_id}
                 </div>
 
                 <div class="form-group">

--- a/www/source/js/main.js
+++ b/www/source/js/main.js
@@ -54,8 +54,6 @@ $(document).ready(function() {
     });
 });
 
-
-    $('#frm-signUpForm-faculty').select2();
     // language=JQuery-CSS
     $(".default-select2").select2();
 


### PR DESCRIPTION
* from document "Fiesta rework": `Bug: when choosing Faculty during creation, this is not saved to profile.`
* field is stored with name `faculty_id`, but form had name `faculty`
* removed legacy call of select2 to field signUpForm-faculty, which doesn't exist at all   