### PR TITLE
Fixed editation of user status on event list #20

### DIFF
--- a/app/Grid/EventGridFactory.php
+++ b/app/Grid/EventGridFactory.php
@@ -24,7 +24,7 @@ class EventGridFactory extends Grid
         $this->pluginRepository = $pluginRepository;
     }
 
-    function createGuestListGrid($id)
+    public function createGuestListGrid($id)
     {
         $grid = $this->createDatagrid();
 
@@ -47,8 +47,7 @@ class EventGridFactory extends Grid
                     ->endOption()
                     ->addOption("unpaid", 'Unpaid')
                     ->setClass('btn-danger')
-                    ->endOption()
-                    ->onChange[] = [$this, "changeStatus"];
+                    ->endOption();
             }
 
             $grid->addAction('delete', '', 'deleteUser!', ["id" => "data_user", "name" => "data_user.name"])

--- a/app/Model/PluginRepository.php
+++ b/app/Model/PluginRepository.php
@@ -644,16 +644,19 @@ class PluginRepository extends Repository
     /**
      * Change status of user in guest list (paid/unpaid)
      *
-     * @param $id
-     * @param $status
+     * @param $id int event ID
+     * @param $user string user ID
+     * @param $status string new status
      *
      * @return int
      */
-    public function changeUserPaidForEvent($id, $status)
+    public function changeUserPaidForEvent($id, $user, $status)
     {
-        $result = $this->database->table("event_list")
-            ->where("data_user", $id)->update(['status' => $status]);
-        return $result;
+        return $this->database
+            ->table("event_list")
+            ->where("data_user", $user)
+            ->where("event", $id)
+            ->update(['status' => $status]);
     }
 
     /**

--- a/app/Model/PluginRepository.php
+++ b/app/Model/PluginRepository.php
@@ -416,8 +416,7 @@ class PluginRepository extends Repository
     public function isEventFree($event)
     {
         $event = $this->getEvent($event);
-        if ($event["price_with_esn"] === 0 && $event["price_without_esn"] === 0) return TRUE;
-        return FALSE;
+        return $event["price_with_esn"] === 0 && $event["price_without_esn"] === 0;
     }
 
     /**


### PR DESCRIPTION
* fixed callback - moved from grid factory to presenter
* fixed implementation in model layer, which changes the status of user in all events, not in one specific (`changeUserPaidForEvent`)
* part of  #20