### PR TITLE
Fixed registration date of user

### DIFF
--- a/app/Model/AuthenticatorFactory.php
+++ b/app/Model/AuthenticatorFactory.php
@@ -122,7 +122,7 @@ class AuthenticatorFactory implements Nette\Security\IAuthenticator
 
             $this->database->table("data_user")->insert([
                 "user_id" => $email,
-                "registered" => $date
+                "registered" => new DateTime()
             ]);
 
             $this->database->table("role_assignment")->insert([


### PR DESCRIPTION
* related to #29
* since PHP type `DateTime` is mutable, following code is setting `registered` same as `valid` (wrong `registered` for all 7k users)
https://github.com/ESNcz/Fiesta/blob/2d45e28cfa85105aef15daaf6c4f2cf804067da7/app/Model/AuthenticatorFactory.php#L102-L126
* after merge, following queries need to be executed on production database (I'll do it)
```sql
update data_user as du
    inner join (
        select du.user_id                    user_id,
               registered - interval 3 month registered
        from data_user du
                 inner join role_assignment ra on ra.data_user = du.user_id and role = 'international'
        order by registered desc
    ) data ON data.user_id = du.user_id
set du.registered = data.registered;

update data_user as du
    inner join (
        select du.user_id                    user_id,
               registered - interval 6 month registered
        from data_user du
                 inner join role_assignment ra on ra.data_user = du.user_id and role = 'member'
        order by registered desc
    ) data ON data.user_id = du.user_id
set du.registered = data.registered;
```